### PR TITLE
fix names displayed in pacmux session

### DIFF
--- a/scripts/pacmux_sessions.sh
+++ b/scripts/pacmux_sessions.sh
@@ -4,14 +4,14 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"
 
 pacmux_sessions(){
-  i=1
-  while IFS= read -r session; do
-    case "$session" in
-      1) printf "%s #{session_name} " "$(ghost $i)";;
-      *) printf "%s " "$(ghost $i)";;
-    esac
-    i=$(($i+1))
-  done <<< "$(tmux list-sessions -F '#{session_attached}')"
+    i=1
+    while IFS="|" read -r session name; do
+        case "$session" in
+            1*) printf "%s${name} " "$(ghost $i)" ;;
+            *) printf "%s" "$(ghost $i)" ;;
+        esac
+        i=$(($i+1))
+    done <<< "$(tmux list-sessions -F '#{session_attached} | #{session_name}')"
 }
 
 pacmux_sessions


### PR DESCRIPTION
sessions shows current session name for every indicators