### PR TITLE
v2.0.0: Full overhaul — bug fixes, new features, code quality

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.{sh,tmux}]
+indent_style = tab
+indent_size = 4
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: .
+          additional_files: pacmux.tmux

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,3 @@
+shell=bash
+external-sources=true
+source-path=scripts

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2017 Eduardo Ruiz Macias
+Copyright 2017-2026 Eduardo Ruiz Macias
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -1,119 +1,192 @@
 # Pacmux
 
-Enables new format strings to allow your Tmux status line to look like `Pᗣᗧ·•·MᗣN`
- 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.md)
+[![ShellCheck](https://github.com/eduarbo/pacmux/actions/workflows/lint.yml/badge.svg)](https://github.com/eduarbo/pacmux/actions/workflows/lint.yml)
+
+A tmux plugin that transforms your status line into a `Pᗣᗧ·•·MᗣN` arcade.
+
 <img src="preview.png" alt="Preview" width="769" />
 
+## Features
+
+- **6 format strings** for fully customizable Pac-Man-themed status lines
+- **Session indicators** — each session rendered as Blinky, Pinky, Inky, or Clyde
+- **Window state mapping** — active (Pac-Man), quiet (dot), activity (pellet), bell (blue ghost)
+- **Power pellet mode** — ghosts turn blue when a window is zoomed
+- **Mouth animation** — Pac-Man alternates between open and closed mouth on each refresh
+- **Character customization** — swap any glyph (Nerd Font icons, emoji, etc.)
+- **Full color control** — override every color via tmux options
+
+## Requirements
+
+- tmux >= 1.9
+- bash >= 4.0
 
 ## Installation
-### Installation with Tmux Plugin Manager (recommended)
 
-Add plugin to the list of TPM plugins in .tmux.conf:
+### With [TPM](https://github.com/tmux-plugins/tpm) (recommended)
 
-    set -g @plugin 'eduarbo/pacmux'
+Add to your `tmux.conf`:
 
-Hit `prefix + I` to fetch the plugin and source it.  You should now be able to
-use the new format strings.
+```tmux
+set -g @plugin 'eduarbo/pacmux'
+```
 
+Press `prefix + I` to install.
 
-## Manual Installation
+### Manual
 
-Clone the repo:
+```bash
+git clone https://github.com/eduarbo/pacmux ~/.tmux/plugins/pacmux
+```
 
-    $ git clone https://github.com/eduarbo/pacmux ~/clone/path
+Add to the bottom of `tmux.conf`:
 
-Add this line to the bottom of `.tmux.conf`:
+```tmux
+run-shell ~/.tmux/plugins/pacmux/pacmux.tmux
+```
 
-    run-shell ~/clone/path/pacmux.tmux
+Reload with `tmux source-file ~/.tmux.conf`.
 
-Reload TMUX environment:
+## Format Strings
 
-    # type this in terminal
-    $ tmux source-file ~/.tmux.conf
+| Format String | Description | Recommended Option |
+|---|---|---|
+| `#{pacmux_overview}` | All sessions + windows of the active session in Pac-Man style | `status-right` |
+| `#{pacmux_sessions}` | Each session as a colored ghost, active session shows its name | `status-left` |
+| `#{pacmux_window_flag}` | Window state as a Pac-Man symbol (dot, pellet, or blue ghost) | `window-status-format` |
+| `#{pacmux_window_flag_zoomed}` | Like `window_flag` but ghosts turn blue when window is zoomed | `window-status-format` |
+| `#{pacmux_pacman}` | The Pac-Man character `ᗧ` in yellow (animated if enabled) | `window-status-current-format` |
+| `#{pacmux_ghost}` | A ghost with cycling color based on window index | `window-status-format` |
 
-Now, you should be able to use the new format strings.
-
-
-## Usage
-
-This plugin enables 4 new format strings to give your status line a `Pᗣᗧ·•·MᗣN` look.
-All of them are available for the Tmux options `status-left`, `status-right`,
-`window-status-format` and `window-status-current-format`.
+### Symbol Mapping
 
 <img src="screenshot.png" alt="Destructuring Pacmux" width="666" />
 
-`#{pacmux_window_flag}` is meant to be used in the `window-status-format` tmux option
-to represent the window flag with a symbol.
+| Symbol | Meaning |
+|---|---|
+| `ᗧ` | Pac-Man — active window |
+| `·` | Pac-Dot — quiet window |
+| `•` | Power Pellet — window with activity |
+| `ᗣ` | Blue Ghost — window with bell |
 
-### Destructuring symbols
-- `ᗧ` Pac-Man represents the active window
-- `·` Pac-Dot represents a quiet window
-- `•` Power Pellet represents a window with activity
-- `ᗣ` Blue Ghost represents a window with bell
+## Example Configuration
 
-`#{pacmux_sessions}` and `#{pacmux_overview}` are meant to be used either in
-`status-left` or `status-right` tmux option.
+```tmux
+# Status left: zoom icon + session ghosts
+set -g status-left-style fg=brightwhite,bold
+set -g status-left '#{?window_zoomed_flag, ,}#{pacmux_sessions} '
 
-`#{pacmux_sessions}` will represent each session as Blinky, Pinky, Inky or
-Clyde. The ghost representing the current session will be followed by the
-session name.
+# Status right: full overview
+set -g status-right '#{pacmux_overview}'
 
-`#{pacmux_overview}` will give you and overview of the sessions and windows of
-the attached session in a `Pᗣᗧ·•·MᗣN` style.
+# Window tabs
+set -g window-status-separator ' '
+set -g window-status-style fg=brightblack,bold,bg=black
+set -g window-status-last-style default
+set -g window-status-activity-style default
+set -g window-status-bell-style default
+set -g window-status-format '#{pacmux_window_flag} #I#[none,fg=brightblack]/#W'
 
-`#{pacmux_pacman}` just prints the Pac-Man-like character `ᗧ` in yellow. Useful
-for `window-status-format` tmux option.
+# Active window tab
+set -g window-status-current-style fg=white,bold,bg=black
+set -g window-status-current-format '#{pacmux_pacman} #I#[none,fg=white]/#W'
+```
 
-### Example of usage
+## Options Reference
 
-To have the same structure as the preview, add the following to `tmux.conf`:
+### Style Options
 
-    # Style for session name and zoom icon
-    set -g status-left-style fg=brightwhite,bold
-    set -g status-left '#{?window_zoomed_flag,  ,}#{pacmux_sessions} '
+Control the colors of each element using tmux style format (see `message-command-style` in the tmux man page).
 
-    set -g status-right '#{pacmux_overview}'
+| Option | Default | Description |
+|---|---|---|
+| `@pacmux-pacman-style` | `fg=yellow` | Pac-Man color |
+| `@pacmux-blinky-style` | `fg=red` | Blinky (1st ghost) color |
+| `@pacmux-pinky-style` | `fg=brightmagenta` | Pinky (2nd ghost) color |
+| `@pacmux-inky-style` | `fg=brightcyan` | Inky (3rd ghost) color |
+| `@pacmux-clyde-style` | `fg=yellow` | Clyde (4th ghost) color |
+| `@pacmux-blue-ghost-style` | `fg=blue` | Vulnerable ghost color |
+| `@pacmux-dots-style` | `fg=white` | Dots and pellets color |
 
-    set -g window-status-separator ' '
-    set -g window-status-style fg=brightblack,bold,bg=black
-    set -g window-status-last-style default
-    set -g window-status-activity-style default
-    set -g window-status-bell-style default
-    set -g window-status-format '#{pacmux_window_flag} #I#[none,fg=brightblack]/#W'
+### Character Options
 
-    set -g window-status-current-style fg=white,bold,bg=black
-    set -g window-status-current-format '#{pacmux_pacman} #I#[none,fg=white]/#W'
+Override the default Unicode characters. Useful for Nerd Font or emoji substitution.
 
-## Changing defaults
+| Option | Default | Description |
+|---|---|---|
+| `@pacmux-pacman-char` | `ᗧ` | Pac-Man (open mouth) |
+| `@pacmux-pacman-close-char` | `ᗤ` | Pac-Man (closed mouth, for animation) |
+| `@pacmux-ghost-char` | `ᗣ` | Ghost |
+| `@pacmux-dot-char` | `·` | Pac-Dot (quiet window) |
+| `@pacmux-pellet-char` | `•` | Power Pellet (activity window) |
 
-By default these styles are used:
+### Behavior Options
 
-- Pac-Man: `fg=yellow`
-- Blinky: `fg=red`
-- Pinky: `fg=brightmagenta`
-- Inky: `fg=brightcyan`
-- Clyde: `fg=yellow`
-- Blue Ghost: `fg=blue`
-- Dots `fg=white`
+| Option | Default | Description |
+|---|---|---|
+| `@pacmux-animate` | `off` | Set to `on` to animate Pac-Man's mouth on each status refresh |
+| `@pacmux-separator` | ` ` (space) | Character between elements in overview and sessions |
 
-Note that these colors depend on your terminal / X11 config.
+### Example: Custom Colors
 
-You can change these defaults by adding the following user variables to
-`tmux.conf`. Use the tmux style format (See the `message-command-style` option).
+```tmux
+set -g @pacmux-blinky-style "fg=#fc0d1b"
+set -g @pacmux-pinky-style "fg=#febafe"
+set -g @pacmux-inky-style "fg=#2dfffe"
+set -g @pacmux-clyde-style "fg=#feb75b"
+set -g @pacmux-blue-ghost-style "fg=#2533fb"
+set -g @pacmux-pacman-style "fg=#ffff00"
+set -g @pacmux-dots-style "fg=#ffb897"
+```
 
-    set -g @pacmux-blinky-style "fg=#fc0d1b"
-    set -g @pacmux-pinky-style "fg=#febafe"
-    set -g @pacmux-inky-style "fg=#2dfffe"
-    set -g @pacmux-clyde-style "fg=#feb75b"
+### Example: Nerd Font Icons
 
-    set -g @pacmux-blue-ghost-style "fg=#2533fb"
-    set -g @pacmux-pacman-style "fg=#ffff00"
-    set -g @pacmux-dots-style "fg=#ffb897"
+```tmux
+set -g @pacmux-pacman-char ""
+set -g @pacmux-ghost-char "󰊠"
+```
 
-Don't forget to reload tmux environment `($ tmux source-file ~/.tmux.conf)` after
-you do this.
- 
+### Example: Enable Animation
+
+```tmux
+set -g @pacmux-animate on
+```
+
+## What's New in v2
+
+- **Bug fix:** Ghost color rotation now correctly starts with Blinky for the first session
+- **Bug fix:** Session names now display properly in `#{pacmux_sessions}`
+- **New:** `#{pacmux_ghost}` format string for per-window colored ghosts
+- **New:** `#{pacmux_window_flag_zoomed}` — power pellet mode (blue ghosts when zoomed)
+- **New:** Pac-Man mouth animation (`@pacmux-animate`)
+- **New:** Character customization (`@pacmux-*-char` options)
+- **New:** Configurable separator (`@pacmux-separator`)
+- **Improved:** Full ShellCheck compliance and CI via GitHub Actions
+- **Improved:** Proper variable quoting and error handling throughout
+
+## Recording a Demo
+
+To record an animated GIF for your own config, you can use [vhs](https://github.com/charmbracelet/vhs):
+
+```bash
+vhs record pacmux-demo.tape
+```
+
+Or use [asciinema](https://asciinema.org/) and convert with [agg](https://github.com/asciinema/agg):
+
+```bash
+asciinema rec pacmux-demo.cast
+agg pacmux-demo.cast pacmux-demo.gif
+```
+
+## Contributing
+
+1. Fork the repo
+2. Create your branch (`git checkout -b my-feature`)
+3. Ensure `shellcheck pacmux.tmux scripts/*.sh` passes
+4. Commit and open a PR
 
 ## License
 
-[MIT](LICENSE.md)
+[MIT](LICENSE.md) - Eduardo Ruiz Macias

--- a/pacmux.tmux
+++ b/pacmux.tmux
@@ -1,40 +1,50 @@
 #!/usr/bin/env bash
 
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/helpers.sh
 source "$CURRENT_DIR/scripts/helpers.sh"
 
 _interpolation=(
 	"\#{pacmux_overview}"
 	"\#{pacmux_sessions}"
+	"\#{pacmux_window_flag_zoomed}"
 	"\#{pacmux_window_flag}"
 	"\#{pacmux_pacman}"
+	"\#{pacmux_ghost}"
 )
 _commands=(
-	"#($CURRENT_DIR/scripts/pacmux_overview.sh #{session_alerts} #{window_id})"
-	"#($CURRENT_DIR/scripts/pacmux_sessions.sh #{session_id})"
+	"#($CURRENT_DIR/scripts/pacmux_overview.sh)"
+	"#($CURRENT_DIR/scripts/pacmux_sessions.sh)"
+	"$(window_flag_zoomed)"
 	"$(window_flag)"
 	"$(pacman)"
+	"#($CURRENT_DIR/scripts/pacmux_ghost.sh #{window_index})"
 )
 
 do_interpolation() {
 	local all_interpolated="$1"
-	for ((i=0; i<${#_commands[@]}; i++)); do
+	local i
+	for ((i = 0; i < ${#_commands[@]}; i++)); do
 		all_interpolated=${all_interpolated//${_interpolation[$i]}/${_commands[$i]}}
 	done
 	echo "$all_interpolated"
 }
 
 update_tmux_option() {
-	local option=$1
-	local option_value=$(get_tmux_option "$option")
-	local new_option_value=$(do_interpolation "$option_value")
+	local option="$1"
+	local option_value
+	option_value=$(get_tmux_option "$option")
+	local new_option_value
+	new_option_value=$(do_interpolation "$option_value")
 	set_tmux_option "$option" "$new_option_value"
 }
 
 update_tmux_window_option() {
-	local option=$1
-	local option_value=$(get_tmux_window_option "$option")
-	local new_option_value=$(do_interpolation "$option_value")
+	local option="$1"
+	local option_value
+	option_value=$(get_tmux_window_option "$option")
+	local new_option_value
+	new_option_value=$(do_interpolation "$option_value")
 	set_tmux_window_option "$option" "$new_option_value"
 }
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,21 +1,22 @@
 #!/usr/bin/env bash
 
 set_tmux_option() {
-	local option=$1
-	local value=$2
-	local flags=$3
+	local option="$1"
+	local value="$2"
+	local flags="${3:-}"
 	tmux set-option -gq"$flags" "$option" "$value"
 }
 
 set_tmux_window_option() {
-  set_tmux_option "$1" "$2" "w"
+	set_tmux_option "$1" "$2" "w"
 }
 
 get_tmux_option() {
-	local option=$1
-	local default_value=$2
-	local flags=$3
-	local option_value="$(tmux show-option -gv"$flags" "$option")"
+	local option="$1"
+	local default_value="${2:-}"
+	local flags="${3:-}"
+	local option_value
+	option_value="$(tmux show-option -gqv"$flags" "$option" 2>/dev/null)" || true
 	if [ -z "$option_value" ]; then
 		echo "$default_value"
 	else
@@ -24,31 +25,72 @@ get_tmux_option() {
 }
 
 get_tmux_window_option() {
-  get_tmux_option "$1" "$2" "w"
+	get_tmux_option "$1" "${2:-}" "w"
 }
 
+# Style options
 blue_ghost_style=$(get_tmux_option "@pacmux-blue-ghost-style" "fg=blue")
 pacman_style=$(get_tmux_option "@pacmux-pacman-style" "fg=yellow")
 dots_style=$(get_tmux_option "@pacmux-dots-style" "fg=white")
 
-pacman(){
-  printf "#[none]#[%s]ᗧ#[default]" "$pacman_style"
+# Character options
+pacman_char=$(get_tmux_option "@pacmux-pacman-char" "ᗧ")
+pacman_close_char=$(get_tmux_option "@pacmux-pacman-close-char" "ᗤ")
+ghost_char=$(get_tmux_option "@pacmux-ghost-char" "ᗣ")
+dot_char=$(get_tmux_option "@pacmux-dot-char" "·")
+pellet_char=$(get_tmux_option "@pacmux-pellet-char" "•")
+
+# Animation option
+animate=$(get_tmux_option "@pacmux-animate" "off")
+
+# Separator option (used by scripts that source this file)
+# shellcheck disable=SC2034
+separator=$(get_tmux_option "@pacmux-separator" " ")
+
+_anim_file="/tmp/pacmux_anim_$(tmux display-message -p '#{pid}' 2>/dev/null || echo $$)"
+
+_get_pacman_char() {
+	if [ "$animate" = "on" ]; then
+		if [ -f "$_anim_file" ]; then
+			rm -f "$_anim_file"
+			printf '%s' "$pacman_close_char"
+		else
+			touch "$_anim_file"
+			printf '%s' "$pacman_char"
+		fi
+	else
+		printf '%s' "$pacman_char"
+	fi
 }
 
-blue_ghost(){
-  printf "#[none]#[%s]ᗣ #[default]" "$blue_ghost_style"
+pacman() {
+	local char
+	char="$(_get_pacman_char)"
+	printf "#[none]#[%s]%s#[default]" "$pacman_style" "$char"
 }
 
-window_flag(){
-	printf "#[none]#[%s]#{?window_bell_flag,,#[none]#[%s]}#{?window_bell_flag,ᗣ,#{?window_activity_flag,•,·}}#[default]" "$blue_ghost_style" "$dots_style"
+blue_ghost() {
+	printf "#[none]#[%s]%s #[default]" "$blue_ghost_style" "$ghost_char"
 }
 
-ghost(){
-  styles=(
-    $(get_tmux_option "@pacmux-blinky-style" "fg=red")
-    $(get_tmux_option "@pacmux-pinky-style" "fg=brightmagenta")
-    $(get_tmux_option "@pacmux-inky-style" "fg=brightcyan")
-    $(get_tmux_option "@pacmux-clyde-style" "fg=yellow")
-  )
-  printf "#[none]#[%s]ᗣ#[default]" "${styles[$1 % 4]}"
+window_flag() {
+	printf "#[none]#[%s]#{?window_bell_flag,,#[none]#[%s]}#{?window_bell_flag,%s,#{?window_activity_flag,%s,%s}}#[default]" \
+		"$blue_ghost_style" "$dots_style" "$ghost_char" "$pellet_char" "$dot_char"
+}
+
+window_flag_zoomed() {
+	printf "#{?window_zoomed_flag,#[none]#[%s]%s#[default],%s}" \
+		"$blue_ghost_style" "$ghost_char" "$(window_flag)"
+}
+
+ghost() {
+	local idx="${1:-0}"
+	local styles
+	styles=(
+		"$(get_tmux_option "@pacmux-blinky-style" "fg=red")"
+		"$(get_tmux_option "@pacmux-pinky-style" "fg=brightmagenta")"
+		"$(get_tmux_option "@pacmux-inky-style" "fg=brightcyan")"
+		"$(get_tmux_option "@pacmux-clyde-style" "fg=yellow")"
+	)
+	printf "#[none]#[%s]%s#[default]" "${styles[$(( (idx - 1) % 4 ))]}" "$ghost_char"
 }

--- a/scripts/pacmux_ghost.sh
+++ b/scripts/pacmux_ghost.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
+source "$CURRENT_DIR/helpers.sh"
+
+window_index="${1:-0}"
+ghost "$(( window_index + 1 ))"

--- a/scripts/pacmux_overview.sh
+++ b/scripts/pacmux_overview.sh
@@ -1,29 +1,33 @@
 #!/usr/bin/env bash
 
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+set -euo pipefail
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
 source "$CURRENT_DIR/helpers.sh"
 
-pacmux_overview(){
-  i=1
-  sessions=($(tmux list-sessions -F '#{session_attached} '))
-  for session in "${sessions[@]}"; do
-    case "$session" in
-      1) printf "%s  " "$(ghost $i)"
-         windows=($(tmux list-windows -F '#{?window_active,1,#{?window_bell_flag,2,#{?window_activity_flag,3,0}}} '))
-         for window in "${windows[@]}"; do
-           case "$window" in
-             1) pacman;;
-             2) blue_ghost;;
-             3) printf "#[none]#[%s]•" "$dots_style";;
-             *) printf "#[none]#[%s]·" "$dots_style";;
-           esac
-         done
-         printf " "
-         ;;
-      *) printf "%s " "$(ghost $i)";;
-    esac
-    i=$(($i+1))
-  done
+pacmux_overview() {
+	local i=1
+	while IFS= read -r attached; do
+		case "$attached" in
+			1)
+				printf "%s %s" "$(ghost "$i")" "$separator"
+				while IFS= read -r wflag; do
+					case "$wflag" in
+						1) pacman ;;
+						2) blue_ghost ;;
+						3) printf "#[none]#[%s]%s" "$dots_style" "$pellet_char" ;;
+						*) printf "#[none]#[%s]%s" "$dots_style" "$dot_char" ;;
+					esac
+				done <<< "$(tmux list-windows -F '#{?window_active,1,#{?window_bell_flag,2,#{?window_activity_flag,3,0}}}')"
+				printf "%s" "$separator"
+				;;
+			*)
+				printf "%s%s" "$(ghost "$i")" "$separator"
+				;;
+		esac
+		i=$(( i + 1 ))
+	done <<< "$(tmux list-sessions -F '#{session_attached}')"
 }
 
 pacmux_overview

--- a/scripts/pacmux_sessions.sh
+++ b/scripts/pacmux_sessions.sh
@@ -1,17 +1,20 @@
 #!/usr/bin/env bash
 
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+set -euo pipefail
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
 source "$CURRENT_DIR/helpers.sh"
 
-pacmux_sessions(){
-  i=1
-  while IFS= read -r session; do
-    case "$session" in
-      1) printf "%s #{session_name} " "$(ghost $i)";;
-      *) printf "%s " "$(ghost $i)";;
-    esac
-    i=$(($i+1))
-  done <<< "$(tmux list-sessions -F '#{session_attached}')"
+pacmux_sessions() {
+	local i=1
+	while IFS="|" read -r attached name; do
+		case "$attached" in
+			1) printf "%s %s%s" "$(ghost "$i")" "$name" "$separator" ;;
+			*) printf "%s%s" "$(ghost "$i")" "$separator" ;;
+		esac
+		i=$(( i + 1 ))
+	done <<< "$(tmux list-sessions -F '#{session_attached}|#{session_name}')"
 }
 
 pacmux_sessions


### PR DESCRIPTION
## Summary

- **Bug fixes:** Ghost color off-by-one (Blinky now first), session name display in `#{pacmux_sessions}` (closes #1), removed unused args from overview script
- **New features:** `#{pacmux_ghost}` format string, `#{pacmux_window_flag_zoomed}` power pellet mode, Pac-Man mouth animation, character customization (`@pacmux-*-char`), configurable separator
- **Code quality:** Full ShellCheck compliance, GitHub Actions CI, `set -euo pipefail`, proper quoting, `while read` loops replacing word-splitting patterns
- **Docs:** Complete README rewrite with badges, options reference tables, v2 changelog, contributing section

## Test plan

- [ ] Install via TPM and verify `#{pacmux_overview}`, `#{pacmux_sessions}`, `#{pacmux_pacman}`, `#{pacmux_window_flag}` render correctly
- [ ] Verify ghost colors cycle Blinky → Pinky → Inky → Clyde (in that order)
- [ ] Verify `#{pacmux_sessions}` shows the active session name
- [ ] Test `#{pacmux_ghost}` in `window-status-format`
- [ ] Test `#{pacmux_window_flag_zoomed}` — ghost turns blue when window is zoomed
- [ ] Enable `@pacmux-animate on` and verify Pac-Man mouth toggles
- [ ] Override characters with `@pacmux-*-char` options and verify
- [ ] Confirm ShellCheck CI passes on the PR